### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Model Context Protocol (MCP) server for Emacs. Enables generating and running elisp code in a running Emacs process.
 
+<a href="https://glama.ai/mcp/servers/@vivekhaldar/emacs-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vivekhaldar/emacs-mcp-server/badge" alt="Emacs Server MCP server" />
+</a>
+
 ## Tools
 
 The server exposes two tools:


### PR DESCRIPTION
This PR adds a badge for the [Emacs MCP Server](https://glama.ai/mcp/servers/@vivekhaldar/emacs-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@vivekhaldar/emacs-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vivekhaldar/emacs-mcp-server/badge" alt="Emacs Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.